### PR TITLE
Comments out duplicate test strings in big_list_of_naughty_strings.txt

### DIFF
--- a/big_list_of_naughty_strings.txt
+++ b/big_list_of_naughty_strings.txt
@@ -177,7 +177,7 @@ invalid_ion::
 "''''"'"
 "'"'"''''"
 <foo val=“bar” />
-<foo val=“bar” />
+# <foo val=“bar” />   # duplicate
 <foo val=”bar“ />
 <foo val=`bar' />
 
@@ -476,9 +476,9 @@ ABC<div style="x:\xE2\x80\x89expression(javascript:alert(1)">DEF
 <img\x10src=x onerror="javascript:alert(1)">
 <img\x13src=x onerror="javascript:alert(1)">
 <img\x32src=x onerror="javascript:alert(1)">
-<img\x47src=x onerror="javascript:alert(1)">
+# <img\x47src=x onerror="javascript:alert(1)">   # duplicate
 <img\x11src=x onerror="javascript:alert(1)">
-<img \x47src=x onerror="javascript:alert(1)">
+# <img \x47src=x onerror="javascript:alert(1)">  # duplicate
 <img \x34src=x onerror="javascript:alert(1)">
 <img \x39src=x onerror="javascript:alert(1)">
 <img \x00src=x onerror="javascript:alert(1)">
@@ -556,7 +556,7 @@ _
 #
 #	Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)
 
--
+# -   # duplicate
 --
 --version
 --help

--- a/big_list_of_naughty_strings.txt
+++ b/big_list_of_naughty_strings.txt
@@ -177,7 +177,7 @@ invalid_ion::
 "''''"'"
 "'"'"''''"
 <foo val=“bar” />
-# <foo val=“bar” />   # duplicate
+# <foo val=“bar” />   # duplicate, see https://github.com/amzn/ion-hash-test/issues/4
 <foo val=”bar“ />
 <foo val=`bar' />
 
@@ -476,9 +476,9 @@ ABC<div style="x:\xE2\x80\x89expression(javascript:alert(1)">DEF
 <img\x10src=x onerror="javascript:alert(1)">
 <img\x13src=x onerror="javascript:alert(1)">
 <img\x32src=x onerror="javascript:alert(1)">
-# <img\x47src=x onerror="javascript:alert(1)">   # duplicate
+# <img\x47src=x onerror="javascript:alert(1)">   # duplicate, see https://github.com/amzn/ion-hash-test/issues/4
 <img\x11src=x onerror="javascript:alert(1)">
-# <img \x47src=x onerror="javascript:alert(1)">  # duplicate
+# <img \x47src=x onerror="javascript:alert(1)">  # duplicate, see https://github.com/amzn/ion-hash-test/issues/4
 <img \x34src=x onerror="javascript:alert(1)">
 <img \x39src=x onerror="javascript:alert(1)">
 <img \x00src=x onerror="javascript:alert(1)">
@@ -556,7 +556,7 @@ _
 #
 #	Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)
 
-# -   # duplicate
+# -   # duplicate, see https://github.com/amzn/ion-hash-test/issues/4
 --
 --version
 --help


### PR DESCRIPTION
I've confirmed that each commented out test string is a duplicate by comparing the bytes with `hexdump -C`.

Commenting the duplicates out (instead of removing them) so these strings can be commented out again if/when an updated big_list_of_naughty_strings.txt is pulled at some point.

Resolves #4 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
